### PR TITLE
Add recursion limit for tables.

### DIFF
--- a/pprint.lua
+++ b/pprint.lua
@@ -1,6 +1,10 @@
 local pprint = { VERSION = '0.1' }
 
+local depth = 1
+
 pprint.defaults = {
+    -- If set to number N, then limit table recursion to N deep.
+    depth_limit = false,
     -- type display trigger, hide not useful datatypes by default
     -- custom types are treated as table
     show_nil = true,
@@ -314,6 +318,11 @@ function pprint.pformat(obj, option, printer)
             end
         end
 
+        local limit = tonumber(option.depth_limit)
+        if limit and depth > limit then
+           return string_formatter(tostring(t), true)
+        end
+
         local tlen = #t
         local wrapped = false
         _p('{')
@@ -365,7 +374,9 @@ function pprint.pformat(obj, option, printer)
                 _p(']')
             end
             _p(' = ', true)
+            depth = depth+1
             _p(format(v), true)
+            depth = depth-1
             _p(',', true)
         end
 


### PR DESCRIPTION
Sometimes you might not want to recur to arbitrary depth.  For instance, I often find myself typing for k,v in pairs(t) do print(k,v) end.  With a recursion depth limit in pprint, I could use that instead, so I added a simple depth counter option.  If you'd rather see this done another way, don't hesitate to tell me what you have in mind.

Thanks!