### PR TITLE
Depth limit

### DIFF
--- a/pprint.lua
+++ b/pprint.lua
@@ -1,6 +1,10 @@
 local pprint = { VERSION = '0.1' }
 
+local depth = 1
+
 pprint.defaults = {
+    -- If set to number N, then limit table recursion to N deep.
+    depth_limit = false,
     -- type display trigger, hide not useful datatypes by default
     -- custom types are treated as table
     show_nil = true,
@@ -314,6 +318,14 @@ function pprint.pformat(obj, option, printer)
             end
         end
 
+        local limit = tonumber(option.depth_limit)
+        if limit and depth > limit then
+           if print_header_ix then
+              return string.format('[[%s %d]]...', ttype, print_header_ix)
+           end
+           return string_formatter(tostring(t), true)
+        end
+
         local tlen = #t
         local wrapped = false
         _p('{')
@@ -331,7 +343,9 @@ function pprint.pformat(obj, option, printer)
                 if option.wrap_array then
                     wrapped = _n()
                 end
+                depth = depth+1
                 _p(format(v)..', ')
+                depth = depth-1
             end
         end
 
@@ -365,7 +379,9 @@ function pprint.pformat(obj, option, printer)
                 _p(']')
             end
             _p(' = ', true)
+            depth = depth+1
             _p(format(v), true)
+            depth = depth-1
             _p(',', true)
         end
 

--- a/tests/options.lua
+++ b/tests/options.lua
@@ -10,6 +10,7 @@ assert_str_equal(pprint.pformat(simple, {
     show_function = false,
     show_thread = false,
     show_userdata = false,
+    depth_limit = false
 }),
 [[
 {}
@@ -235,6 +236,39 @@ assert_str_equal(pprint.pformat(t, {
 }
 ]]
 )
+end)
+
+test('depth_limit', function ()
+local a = { 1, 2, 3, 4, 5 }
+local t = { a, { a }}
+
+assert_str_equal(pprint.pformat(t, { depth_limit=2 }),
+[==[ { { --[[table 2]] 1, 2, 3, 4, 5 }, { [[table 2]] } } ]==])
+
+assert_str_match(pprint.pformat(t, { depth_limit=1 }),
+[==[{%-%[%[table%-2%]%]%.%.%.,%-%[%[table:%-0x[0-9a-f]+%]%]%-}]==])
+
+assert_str_match(pprint.pformat(t, { depth_limit=0 }),
+[==[%[%[table:%-0x[0-9a-f]+%]%]]==])
+
+a = { book1 = 'book1', book10 = 'book10', book2 = 'book2' }
+t = { a, { a }}
+
+assert_str_equal(pprint.pformat(t, { depth_limit=2 }),
+[==[
+{ { --[[table 2]]
+    book1 = 'book1',
+    book2 = 'book2',
+    book10 = 'book10'
+  }, { [[table 2]] } }
+]==])
+
+assert_str_match(pprint.pformat(t, { depth_limit=1 }),
+[==[{%-%[%[table%-2%]%]%.%.%.,%-%[%[table:%-0x[0-9a-f]+%]%]%-}]==])
+
+assert_str_match(pprint.pformat(t, { depth_limit=0 }),
+[==[%[%[table:%-0x[0-9a-f]+%]%]]==])
+
 end)
 
 -- it's actually quite difficult to test unsorted, as we must ensure it's as

--- a/tests/runner.lua
+++ b/tests/runner.lua
@@ -42,6 +42,13 @@ function assert_str_equal(lhs, rhs)
     end
 end
 
+function assert_str_match(str,pat)
+   str=normalize(str)
+   if not string.match(str,pat) then
+      error(string.format('pattern match failed!\ntrimmed string:\n>>>\n%s\n<<<\npattern:\n>>>\n%s\n<<<\n', str, pat), 2)
+   end
+end
+
 _G.pprint = pprint
 _G.type = newtype
 _G.test = test


### PR DESCRIPTION
Here's a new version of recursion depth limiting.   I previously forgot to limit the array part, and I also failed to output table cache numbers rather than raw table numbers in that previous pull.  I added a pattern match test as there are times when raw table numbers are written, and so a fixed match string won't work.  I've put this on a separate branch to be a bit more tidy.  I'm dogfooding this with some simple Linux utilities I'm developing for WINE VST support, so you'll hear about any hiccoughs I run into.  Thanks for your patience.